### PR TITLE
chore: update local action references

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # https://github.com/pnpm/action-setup/releases/tag/v6.0.3
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # https://github.com/pnpm/action-setup/releases/tag/v5.0.0
       name: Install pnpm
       with:
         run_install: false

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # https://github.com/pnpm/action-setup/releases/tag/v6.0.3
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # https://github.com/pnpm/action-setup/releases/tag/v5.0.0
       name: Install pnpm
       with:
         run_install: false


### PR DESCRIPTION
This PR updates third-party GitHub Action references used by `.github/actions/**/action.yml`.

Generated automatically by the `update-local-action-uses` workflow because Dependabot does not update `uses:` entries inside local composite actions.