### PR TITLE
chore: update local action references

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # https://github.com/pnpm/action-setup/releases/tag/v6.0.5
+    - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # https://github.com/pnpm/action-setup/releases/tag/v6.0.6
       name: Install pnpm
       with:
         run_install: false

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # https://github.com/pnpm/action-setup/releases/tag/v6.0.5
+    - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # https://github.com/pnpm/action-setup/releases/tag/v6.0.6
       name: Install pnpm
       with:
         run_install: false


### PR DESCRIPTION
This PR updates third-party GitHub Action references used by `.github/actions/**/action.yml`.

Generated automatically by the `update-local-action-uses` workflow because Dependabot does not update `uses:` entries inside local composite actions.