### PR TITLE
chore: update node and pnpm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   ],
   "engines": {
     "node": ">=24",
-    "pnpm": "^11.17.0"
+    "pnpm": "^11.18.0"
   },
-  "packageManager": "pnpm@11.17.0"
+  "packageManager": "pnpm@11.18.0"
 }


### PR DESCRIPTION
This PR updates the repository toolchain versions tracked in:
- `package.json`
- `.github/actions/**/action.yml`
- workflows that bootstrap Node.js directly

Resolved by automation:
- Node.js LTS major: `24`
- pnpm version: `11.18.0`